### PR TITLE
Add support for sending user properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Add ability to toggle sending of analytics events to tracking tools. Useful for GDPR compliance.
+- Add support for sending user properties to analytics trackers.
 
 ## [1.1.0] - 2025-02-22
 

--- a/kanalytics/src/commonMain/kotlin/com/addhen/kanalytics/KAnalyticsEvent.kt
+++ b/kanalytics/src/commonMain/kotlin/com/addhen/kanalytics/KAnalyticsEvent.kt
@@ -14,14 +14,17 @@ public class KAnalyticsEvent(
   public val eventName: String,
   public val eventDescription: String? = null,
   properties: Map<String, Any?> = emptyMap(),
+  userProperties: Map<String, Any?> = emptyMap(),
 ) {
 
   private val _properties = properties.toMutableMap()
+  private val _userProperties = userProperties.toMutableMap()
 
   public val properties: Map<String, Any?> = _properties
+  public val userProperties: Map<String, Any?> = _userProperties
 
   /**
-   * Adds a property to the event.
+   * Adds a custom event property to the event.
    * @param propertyName The name of the property.
    * @param value The value of the property.
    */
@@ -30,13 +33,32 @@ public class KAnalyticsEvent(
   }
 
   /**
-   * Adds multiple properties to the event.
+   * Adds custom event properties to the event.
    *
    * @param map A map of properties to add.
    */
   public fun addProperties(map: Map<String, Any?>): KAnalyticsEvent = apply {
     _properties.putAll(map)
   }
+
+  /**
+   * Adds user properties to the event.
+   *
+   * @param map A map of user properties to add.
+   */
+    public fun addUserProperties(map: Map<String, Any?>): KAnalyticsEvent = apply {
+      _userProperties.putAll(map)
+    }
+
+  /**
+   * Adds a user property to the event.
+
+   * @param propertyName The name of the property.
+   * @param value The value of the property.
+   */
+    public fun addUserProperty(propertyName: String, value: Any?): KAnalyticsEvent = apply {
+      _userProperties[propertyName] = value
+    }
 
   /**
    * Creates a copy of the event with the specified properties.
@@ -49,7 +71,13 @@ public class KAnalyticsEvent(
     eventName: String = this.eventName,
     eventDescription: String? = this.eventDescription,
     properties: Map<String, Any?> = this.properties,
-  ): KAnalyticsEvent = KAnalyticsEvent(eventName, eventDescription, properties)
+    userProperties: Map<String, Any?> = this.userProperties,
+  ): KAnalyticsEvent = KAnalyticsEvent(
+    eventName,
+    eventDescription,
+    properties,
+    userProperties
+  )
 
   /**
    * Returns a string representation of the event.
@@ -58,5 +86,6 @@ public class KAnalyticsEvent(
     "eventName='$eventName', " +
     "eventDescription='$eventDescription', " +
     "properties=$properties" +
+    "userProperties=$userProperties" +
     ")"
 }

--- a/kanalytics/src/commonMain/kotlin/com/addhen/kanalytics/KAnalyticsEvent.kt
+++ b/kanalytics/src/commonMain/kotlin/com/addhen/kanalytics/KAnalyticsEvent.kt
@@ -46,9 +46,9 @@ public class KAnalyticsEvent(
    *
    * @param map A map of user properties to add.
    */
-    public fun addUserProperties(map: Map<String, Any?>): KAnalyticsEvent = apply {
-      _userProperties.putAll(map)
-    }
+  public fun addUserProperties(map: Map<String, Any?>): KAnalyticsEvent = apply {
+    _userProperties.putAll(map)
+  }
 
   /**
    * Adds a user property to the event.
@@ -56,9 +56,9 @@ public class KAnalyticsEvent(
    * @param propertyName The name of the property.
    * @param value The value of the property.
    */
-    public fun addUserProperty(propertyName: String, value: Any?): KAnalyticsEvent = apply {
-      _userProperties[propertyName] = value
-    }
+  public fun addUserProperty(propertyName: String, value: Any?): KAnalyticsEvent = apply {
+    _userProperties[propertyName] = value
+  }
 
   /**
    * Creates a copy of the event with the specified properties.
@@ -76,7 +76,7 @@ public class KAnalyticsEvent(
     eventName,
     eventDescription,
     properties,
-    userProperties
+    userProperties,
   )
 
   /**

--- a/kanalytics/src/commonTest/kotlin/com.addhen.kanalytics/KAnalyticsTest.kt
+++ b/kanalytics/src/commonTest/kotlin/com.addhen.kanalytics/KAnalyticsTest.kt
@@ -292,7 +292,7 @@ class KAnalyticsTest {
     override fun send(event: KAnalyticsEvent) {
       println("firebase: $event")
       // Send event to firebase
-      if(event.userProperties.isNotEmpty()) {
+      if (event.userProperties.isNotEmpty()) {
         userProperties.add(event)
       }
       if (event.properties.isNotEmpty()) {

--- a/kanalytics/src/commonTest/kotlin/com.addhen.kanalytics/KAnalyticsTest.kt
+++ b/kanalytics/src/commonTest/kotlin/com.addhen.kanalytics/KAnalyticsTest.kt
@@ -203,6 +203,43 @@ class KAnalyticsTest {
     assertTrue(firebaseTracker.analyticsEvents.isEmpty())
   }
 
+  @Test
+  fun `should send user properties to all trackers`() {
+    val event = KAnalyticsEvent(EVENT_NAME).apply {
+      addUserProperties(
+        mapOf(
+          KEY_ONE to VALUE_ONE,
+          KEY_TWO to VALUE_TWO,
+        ),
+      )
+    }
+
+    kanalytics.send(event)
+
+    assertEquals(0, firebaseTracker.analyticsEvents.size)
+    assertEquals(0, adjustTracker.analyticsEvents.size)
+    assertEquals(1, firebaseTracker.userProperties.size)
+    assertEquals(1, adjustTracker.userProperties.size)
+    assertNull(mockTrackerIntercept.event)
+    assertHasUserPropertiesEvent(firebaseTracker.userProperties)
+    assertHasUserPropertiesEvent(adjustTracker.userProperties)
+  }
+
+  @Test
+  fun `should send user properties event to a specific tracker`() {
+    val event = KAnalyticsEvent(EVENT_NAME).apply {
+      addUserProperty(KEY_ONE, VALUE_ONE)
+      addUserProperty(KEY_TWO, VALUE_TWO)
+    }
+
+    kanalytics.send(event, FirebaseTracker::class)
+
+    assertEquals(0, adjustTracker.analyticsEvents.size)
+    assertEquals(1, firebaseTracker.userProperties.size)
+    assertNull(mockTrackerIntercept.event)
+    assertHasUserPropertiesEvent(firebaseTracker.userProperties)
+  }
+
   private fun assertHasEvent(event: KAnalyticsEvent) {
     assertEquals(EVENT_NAME, event.eventName)
     assertEquals(3, event.properties.size)
@@ -226,23 +263,57 @@ class KAnalyticsTest {
     }
   }
 
+  private fun assertHasUserPropertiesEvent(events: List<KAnalyticsEvent>) {
+    assertTrue(events.isNotEmpty())
+    events.forEach { event -> assertHasUserPropertiesEvent(event) }
+  }
+
+  private fun assertUserPropertiesEvent(events: List<KAnalyticsEvent>) {
+    assertTrue(events.isNotEmpty())
+    events.forEach { event ->
+      assertEquals(EVENT_NAME, event.eventName)
+      assertEquals(2, event.userProperties.size)
+      assertEquals(VALUE_ONE, event.userProperties[KEY_ONE])
+    }
+  }
+
+  private fun assertHasUserPropertiesEvent(event: KAnalyticsEvent) {
+    assertEquals(EVENT_NAME, event.eventName)
+    assertEquals(2, event.userProperties.size)
+    assertEquals(VALUE_ONE, event.userProperties[KEY_ONE])
+    assertEquals(VALUE_TWO, event.userProperties[KEY_TWO])
+  }
+
   inner class FirebaseTracker : KTracker {
 
     val analyticsEvents = mutableListOf<KAnalyticsEvent>()
+    val userProperties = mutableListOf<KAnalyticsEvent>()
 
     override fun send(event: KAnalyticsEvent) {
+      println("firebase: $event")
       // Send event to firebase
-      analyticsEvents.add(event)
+      if(event.userProperties.isNotEmpty()) {
+        userProperties.add(event)
+      }
+      if (event.properties.isNotEmpty()) {
+        analyticsEvents.add(event)
+      }
     }
   }
 
   inner class AdjustTracker : KTracker {
 
     val analyticsEvents = mutableListOf<KAnalyticsEvent>()
+    val userProperties = mutableListOf<KAnalyticsEvent>()
 
     override fun send(event: KAnalyticsEvent) {
-      // Send event to adjust
-      analyticsEvents.add(event)
+      if (event.userProperties.isNotEmpty()) {
+        userProperties.add(event)
+      }
+      if (event.properties.isNotEmpty()) {
+        // Send event to adjust
+        analyticsEvents.add(event)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #36 

The aim of this PR is to be able to send user properties to the different trackers. This is different from the normal custom events sent via the trackers so it needs to be handled separately.

There are two approaches I'm thinking.

1: define a new property called `userProperties: Map<String, Any?>` on `KAnalyticsEvent`. This way when implementing a tracker, in the implementation of the tracker, you decide to send the userProperties if it's not empty.

```kotlin
public class KAnalyticsEvent(
  public val eventName: String,
  public val eventDescription: String? = null,
  properties: Map<String, Any?> = emptyMap(),
  userProperties: Map<String, Any?> = emptyMap(),
) {
...
  public fun addUserProperties(map: Map<String, Any?>): KAnalyticsEvent = apply {
    _userProperties.putAll(map)
  }

  public fun addUserProperty(propertyName: String, value: Any?): KAnalyticsEvent = apply {
    _userProperties[propertyName] = value
  }
...
}
```

2: Define new function on `KTracker` interface to force implementation to handle sending user profile. The problem with this is that if a particular tracker doesn't support sending user profiles the contract is enforced and this could lead to implementing a no-op function.

```kotlin
public interface KTracker {

  public fun send(event: KAnalyticsEvent)

  public fun sendUserProperties(event: KAnalyticsEvent)
}
```