### PR TITLE
Migrate to Dokka Gradle Plug to V2 and Fix Deprecated Warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,18 +16,20 @@ captures
 .idea/modules.xml
 .idea/compiler.xml
 .idea/other.xml
+.idea/kotlinc.xml
 .idea/jarRepositories.xml
 .idea/deploymentTargetDropDown.xml
 .idea/deploymentTargetSelector.xml
 .idea/androidTestResultsUserPreferences.xml
 .idea/appInsightsSettings.xml
 .idea/artifacts
+.idea/AndroidProjectSystem.xml
+.idea/deviceManager.xml
+.idea/studiobot.xml
 .idea/assetWizardSettings.xml
 .idea/runConfigurations.xml
-.idea/studiobot.xml
 gradle.xml
 *.iml
-ios-app/Fosdem/.idea/*
 .fleet
 
 # General

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+kanalytics-lib

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
-  </component>
-</project>

--- a/convention-plugins/src/main/kotlin/com/addhen/gradle/convention/Kotlin.kt
+++ b/convention-plugins/src/main/kotlin/com/addhen/gradle/convention/Kotlin.kt
@@ -17,6 +17,7 @@ fun Project.configureKotlin() {
       // Turning this off due to:
       //https://youtrack.jetbrains.com/issue/KT-66568/w-KLIB-resolver-The-same-uniquename...-found-in-more-than-one-library
       allWarningsAsErrors.set(false)
+      optIn.add("kotlin.time.ExperimentalTime")
       freeCompilerArgs.add(
         // expect/actual classes (including interfaces, objects, annotations, enums, actual typealiases) in Beta
         // https://youtrack.jetbrains.com/issue/KT-61573

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ kotlin.mpp.enableCInteropCommonization=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 kanalytics.sampleDebug=debug
+
+#Dokka V2 Migration
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 # If it's changed, update the one in the script as well.
 kanalytics = "1.4.0-SNAPSHOT"
 minSdk = "24"
-targetSdk = "35"
-compileSdk = "35"
+targetSdk = "36"
+compileSdk = "36"
 agp = "8.13.0"
 kotlin = "2.2.20"
 spotless = "7.2.1"

--- a/kanalytics-viewer-no-op/build.gradle.kts
+++ b/kanalytics-viewer-no-op/build.gradle.kts
@@ -5,7 +5,7 @@
 plugins {
   id("convention.plugin.android.library")
   id("convention.plugin.kotlin.multiplatform")
-  id("org.jetbrains.dokka")
+  alias(libs.plugins.dokka)
   id("convention.plugin.maven.publication")
   id("convention.plugin.metalava")
 }

--- a/kanalytics-viewer-no-op/src/commonMain/kotlin/com/addhen/kanalytics/viewer/KAnalyticsCollector.kt
+++ b/kanalytics-viewer-no-op/src/commonMain/kotlin/com/addhen/kanalytics/viewer/KAnalyticsCollector.kt
@@ -5,7 +5,7 @@ package com.addhen.kanalytics.viewer
 
 import com.addhen.kanalytics.KAnalyticsEvent
 import com.addhen.kanalytics.KTrackerName
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public class KAnalyticsCollector(
   private val showNotification: Boolean = false,

--- a/kanalytics-viewer/build.gradle.kts
+++ b/kanalytics-viewer/build.gradle.kts
@@ -5,7 +5,7 @@
 plugins {
   id("convention.plugin.android.library")
   id("convention.plugin.kotlin.multiplatform")
-  id("org.jetbrains.dokka")
+  alias(libs.plugins.dokka)
   id("convention.plugin.maven.publication")
   id("convention.plugin.compose")
   id("convention.plugin.metalava")

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/KAnalyticsCollector.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/KAnalyticsCollector.kt
@@ -10,11 +10,11 @@ import com.addhen.kanalytics.viewer.app.shared.AppCoroutineDispatchers
 import com.addhen.kanalytics.viewer.app.shared.data.model.EventData
 import com.addhen.kanalytics.viewer.app.shared.data.repository.EventDataRepository
 import com.addhen.kanalytics.viewer.app.shared.data.repository.EventRepository
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 
 public class KAnalyticsCollector(
   showShortcut: Boolean = true,

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/KAnalyticsInterceptor.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/KAnalyticsInterceptor.kt
@@ -5,7 +5,7 @@ package com.addhen.kanalytics.viewer
 
 import com.addhen.kanalytics.Interceptor
 import com.addhen.kanalytics.KAnalyticsEvent
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public class KAnalyticsInterceptor(
   private val collector: KAnalyticsCollector = KAnalyticsCollector(),

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/RetentionPolicyManager.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/RetentionPolicyManager.kt
@@ -5,8 +5,8 @@ package com.addhen.kanalytics.viewer
 
 import com.addhen.kanalytics.viewer.app.shared.data.repository.EventRepository
 import kotlin.jvm.JvmInline
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 public class RetentionPolicyManager(
   private val clock: Clock = Clock.System,
@@ -18,7 +18,11 @@ public class RetentionPolicyManager(
     val daysInMillis = dayDuration.numberOfDays * 24 * 60 * 60 * 1000L
     val currentTimeInMillis = clock.now().toEpochMilliseconds()
     val retentionDeadlineInMillis = currentTimeInMillis - daysInMillis
-    repository.deleteAllOlderThan(Instant.fromEpochMilliseconds(retentionDeadlineInMillis))
+    repository.deleteAllOlderThan(
+      Instant.fromEpochMilliseconds(
+        retentionDeadlineInMillis,
+      ),
+    )
   }
 
   @JvmInline

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/database/EventDataDao.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/database/EventDataDao.kt
@@ -8,11 +8,11 @@ import com.addhen.kanalytics.viewer.app.shared.AppCoroutineDispatchers
 import com.addhen.kanalytics.viewer.app.shared.data.database.entities.EventDataEntity
 import com.addhen.kanalytics.viewer.app.shared.data.database.sqlidelight.EventViewerDatabase
 import com.addhen.kanalytics.viewer.app.shared.data.database.sqlidelight.createDatabase
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 
 public class EventDataDao(
   private val database: EventViewerDatabase,

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/database/entities/EventDataEntity.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/database/entities/EventDataEntity.kt
@@ -3,13 +3,11 @@
 
 package com.addhen.kanalytics.viewer.app.shared.data.database.entities
 
-import kotlinx.datetime.Instant
-
 internal class EventDataEntity(
   val id: Long?,
   val name: String,
   val trackerName: String,
   val description: String?,
-  val createdAt: Instant,
+  val createdAt: kotlin.time.Instant,
   val properties: Map<String, Any>,
 )

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/database/sqlidelight/adapters/InstantAdapter.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/database/sqlidelight/adapters/InstantAdapter.kt
@@ -4,11 +4,11 @@
 package com.addhen.kanalytics.viewer.app.shared.data.database.sqlidelight.adapters
 
 import app.cash.sqldelight.ColumnAdapter
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 internal val instantAdapter = object : ColumnAdapter<Instant, String> {
 
-  override fun decode(databaseValue: String): Instant = Instant.parse(databaseValue)
+  override fun decode(databaseValue: String): Instant = kotlin.time.Instant.parse(databaseValue)
 
   override fun encode(value: Instant): String = value.toString()
 }

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/model/EventData.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/model/EventData.kt
@@ -3,7 +3,7 @@
 
 package com.addhen.kanalytics.viewer.app.shared.data.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 public class EventData(
   public val id: Long?,

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/repository/EventDataRepository.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/repository/EventDataRepository.kt
@@ -6,9 +6,9 @@ package com.addhen.kanalytics.viewer.app.shared.data.repository
 import com.addhen.kanalytics.viewer.app.shared.data.database.EventDataDao
 import com.addhen.kanalytics.viewer.app.shared.data.database.entities.EventDataEntity
 import com.addhen.kanalytics.viewer.app.shared.data.model.EventData
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.datetime.Instant
 
 public class EventDataRepository(private val eventDataDao: EventDataDao) : EventRepository {
 

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/repository/EventRepository.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/data/repository/EventRepository.kt
@@ -4,8 +4,8 @@
 package com.addhen.kanalytics.viewer.app.shared.data.repository
 
 import com.addhen.kanalytics.viewer.app.shared.data.model.EventData
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Instant
 
 public interface EventRepository {
 

--- a/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/ui/Instant.kt
+++ b/kanalytics-viewer/src/commonMain/kotlin/com/addhen/kanalytics/viewer/app/shared/ui/Instant.kt
@@ -1,7 +1,7 @@
 // Copyright 2025, Addhen Ltd and the kanalytics project contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 

--- a/kanalytics-viewer/src/commonMain/sqldelight/com/addhen/kanalytics/viewer/app/shared/data/database/sqlidelight/event_data.sq
+++ b/kanalytics-viewer/src/commonMain/sqldelight/com/addhen/kanalytics/viewer/app/shared/data/database/sqlidelight/event_data.sq
@@ -1,7 +1,7 @@
 import kotlin.String;
 import kotlin.Any;
 import kotlin.collections.Map;
-import kotlinx.datetime.Instant;
+import kotlin.time.Instant;
 
 PRAGMA user_version = 3;
 

--- a/kanalytics-viewer/src/commonTest/kotlin/com.addhen.kanalytics/viewer/KAnalyticsCollectorTest.kt
+++ b/kanalytics-viewer/src/commonTest/kotlin/com.addhen.kanalytics/viewer/KAnalyticsCollectorTest.kt
@@ -14,6 +14,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -24,8 +26,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class KAnalyticsCollectorTest {

--- a/kanalytics-viewer/src/commonTest/kotlin/com.addhen.kanalytics/viewer/RetentionPolicyManagerTest.kt
+++ b/kanalytics-viewer/src/commonTest/kotlin/com.addhen.kanalytics/viewer/RetentionPolicyManagerTest.kt
@@ -13,9 +13,9 @@ import dev.mokkery.verifySuspend
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 class RetentionPolicyManagerTest {
   private lateinit var clock: TestClock
@@ -43,7 +43,11 @@ class RetentionPolicyManagerTest {
     manager.processDataRetention()
 
     verifySuspend {
-      repository.deleteAllOlderThan(Instant.fromEpochMilliseconds(expectedRetentionDeadline))
+      repository.deleteAllOlderThan(
+        kotlin.time.Instant.fromEpochMilliseconds(
+          expectedRetentionDeadline,
+        ),
+      )
     }
   }
 

--- a/kanalytics/build.gradle.kts
+++ b/kanalytics/build.gradle.kts
@@ -5,7 +5,7 @@
 plugins {
   id("convention.plugin.android.library")
   id("convention.plugin.kotlin.multiplatform")
-  id("org.jetbrains.dokka")
+  alias(libs.plugins.dokka)
   id("convention.plugin.maven.publication")
   id("convention.plugin.metalava")
 }


### PR DESCRIPTION
Fixes #89 with the follow changes:

- Remove unnecessary .idea files being tracked by git
- Bump target SDK 36 to fix build warnings
- Fix deprecated warnings from `kotlin.time` package